### PR TITLE
Fix to add/remove values also from response

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ policies:
         response:
           add:
           - name: createdBy
-            value: "'Clark Kent'"
+            value: res.body.fullname
           remove:
           - uselessParam
 ```

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ const plugin = {
                 const _write = res.write;
                 res.write = (data) => {
                   try {
+                    res.body = JSON.parse(data);
                     const body = transformBody(params.response, req.egContext, JSON.parse(data));
                     const bodyData = JSON.stringify(body);
 


### PR DESCRIPTION
Regarding the issue #1 
Probably closes #1 

With @kevinswiber and @XVincentX emerged this situation and we tought that’s a worthwhile change to the plugin.

Use case:
We finished working on v2 api service.
While working on v2 clients or for not updated clients we need the response payload structure to stay the same.

So i take new keys from response v2 and map to "old" v1 keys, but of course with new values.
